### PR TITLE
Bulk Transport

### DIFF
--- a/protocol
+++ b/protocol
@@ -16,7 +16,7 @@ Each server has a root actor, with which the client first interacts. The root ac
 
 For example, a debugger might connect to a browser, ask the root actor to list the browser's tabs, and present this list to the developer. If the developer chooses some tabs to debug, then the debugger can send <tt>attach</tt> requests to the actors representing those tabs, to begin debugging.
 
-Actor names are JSON strings. The name of the root actor is <code>"root"</code>.
+Actor names are JSON strings, containing no spaces or colons. The name of the root actor is <code>"root"</code>.
 
 To allow the server to reuse actor names and the resources they require, actors have limited lifetimes. All actors in a server form a tree, whose root is the root actor. Closing communications with an actor automatically closes communications with its descendants. For example, the actors representing a thread's stack frames are children of the actor representing the thread itself, so that when a debugger detaches from a thread, which closes the thread's actor, the frames' actors are automatically closed. This arrangement allows the protocol to mention actors liberally, without making the client responsible for explicitly closing every actor that has ever been mentioned.
 

--- a/transport
+++ b/transport
@@ -1,3 +1,5 @@
+<i>This transport is implemented in Firefox, and is the basis of Firefox's built-in JavaScript debugger. You can use the [https://github.com/jimblandy/DebuggerDocs GitHub DebuggerDocs repo] to draft and discuss revisions.</i>
+
 The [[Remote_Debugging_Protocol|Mozilla debugging protocol]] is specified in terms of packets exchanged between a client and server, where each packet is either a JSON text or a block of bytes (a "bulk data" packet). The protocol does not specify any particular mechanism for carrying packets from one party to the other. Implementations may choose whatever transport they like, as long as packets arrive reliably, undamaged, and in order.
 
 This page describes the <b>Mozilla Remote Debugging Protocol Stream Transport</b>, a transport layer suitable for carrying Mozilla debugging protocol packets over a reliable, ordered byte stream, like a TCP/IP stream or a pipe. Debugger user interfaces can use it to exchange packets with debuggees in other processes (say, for debugging Firefox chrome code), or on other machines (say, for debugging Firefox OS apps running on a phone or tablet).
@@ -22,19 +24,22 @@ where <i>length</i> is a series of decimal ASCII digits, <i>JSON</i> is a well-f
 
 A bulk data packet has the form:
 
-  bulk <i>actor</i> <i>length</i>:<i>data</i>
+  bulk <i>actor</i> <i>type</i> <i>length</i>:<i>data</i>
 
 where:
 <ul>
-<li>The keyword <code>bulk</code> is encoded in ASCII, and the spaces are always exactly one ASCII space.
-<li><i>actor</i> is a sequence of Unicode characters, encoded in UTF-8, containing no spaces or colons;
-<li><i>length</i> is a sequence of decimal ASCII digits; and
-<li><i>data</i> is a sequence of bytes whose length is <i>length</i> interpreted as a number.
+<li>The keyword <code>bulk</code> is encoded in ASCII, and the spaces are always exactly one ASCII space
+<li><i>actor</i> is a sequence of Unicode characters, encoded in UTF-8, containing no spaces
+<li><i>type</i> is a sequence of Unicode characters, encoded in UTF-8, containing no spaces
+<li><i>length</i> is a sequence of decimal ASCII digits
+<li><i>data</i> is a sequence of bytes whose length is <i>length</i> interpreted as a number
 </ul>
 
 The <i>actor</i> field is the name of the actor sending or receiving the packet. (Actors are server-side entities, so if the packet was sent by the client, <i>actor</i> names the recipient; and if the packet was sent by the server, <i>actor</i> names the sender.) The protocol imposes the same syntactic restrictions on actor names that we require here.
 
 Which actor names are valid at any given point in an exchange is established by the remote debugging protocol.
+
+The <i>type</i> field defines the type of the packet, which may be used with the actor name to route the packet to its destination properly. The protocol provides more detail about the <i>type</i>, which remains in effect here.
 
 The content of a bulk data packet is exactly the sequence of bytes appearing as <i>data</i>. <i>Data</i> is not UTF-8 text.
 
@@ -53,9 +58,9 @@ TCP/IP streams and USB streams meet these requirements.
 
 === Constant-Overhead Bulk Data ===
 
-Mozilla added bulk data packets to the protocol to let devices with limited memory upload performance profiling data more efficiently. Profiling data sets need to be as large as possible, as larger data sets can cover a longer period of time or more frequent samples. However, converting a large data set to a JavaScript object, converting that object to a JSON text, and sending the text over the connection entails making several temporary complete copies of the data; on small devices, this limits how much data the profiler can collect. Avoiding these temporary copies would allow small devices to collect and transmit larger profile data sets. Since it seemed likely that other sorts of tools would need to exchange large binary blocks efficiently as well, we wanted a solution usable by all protocol participants, rather than one tailored to the profiler's specific case.
+Mozilla added bulk data packets to the protocol to let devices with limited memory upload performance profiling and other large data sets more efficiently. Profiling data sets need to be as large as possible, as larger data sets can cover a longer period of time or more frequent samples. However, converting a large data set to a JavaScript object, converting that object to a JSON text, and sending the text over the connection entails making several temporary complete copies of the data; on small devices, this limits how much data the profiler can collect. Avoiding these temporary copies would allow small devices to collect and transmit larger profile data sets. Since it seemed likely that other sorts of tools would need to exchange large binary blocks efficiently as well, we wanted a solution usable by all protocol participants, rather than one tailored to the profiler's specific case.
 
-In our implementation of this Stream Transport, when a participant wishes to transmit a bulk data packet, it provides the actor name, the data's length in bytes, and a callback function. When the underyling stream is ready to send more data, the transport writes the packet's <code>bulk <i>actor</i> <i>length</i>:</code> header, and then passes the underlying <code>nsIOutputStream</code> to the callback, which then writes the packet's <i>data</i> portion directly to the stream. Similarly, when a participant receives a bulk data packet, the transport parses the header, and then passes the actor name and the transport's underlying <code>nsIInputStream</code> to a callback function, which consumes the data directly. Thus, while the callback functions may well use fixed-size buffers to send and receive data, the transport imposes no overhead proportional to the full size of the data.
+In our implementation of this Stream Transport, when a participant wishes to transmit a bulk data packet, it provides the actor name, the type, the data's length in bytes, and a callback function. When the underlying stream is ready to send more data, the transport writes the packet's <code>bulk <i>actor</i> <i>type</i> <i>length</i>:</code> header, and then passes the underlying <code>nsIOutputStream</code> to the callback, which then writes the packet's <i>data</i> portion directly to the stream. Similarly, when a participant receives a bulk data packet, the transport parses the header, and then passes the actor name, type, and the transport's underlying <code>nsIInputStream</code> to a callback function, which consumes the data directly. Thus, while the callback functions may well use fixed-size buffers to send and receive data, the transport imposes no overhead proportional to the full size of the data.
 
 <!-- Local Variables: -->
 <!-- eval: (visual-line-mode) -->

--- a/transport
+++ b/transport
@@ -50,6 +50,14 @@ The Stream Transport requires the underlying stream to have the following proper
 
 TCP/IP streams and USB streams meet these requirements.
 
+== Implementation Notes ==
+
+=== Zero-copy Bulk Data ===
+
+Mozilla added bulk data packets to the protocol to download profiling data from devices with limited memory more efficiently. Profiling data sets need to be as large as possible, as larger sets can cover a longer period of time or more frequent samples. However, converting a large data set to a JavaScript object, converting the object to a JSON text, and sending the text over the connection entails making several temporary copies of the data, and thus limits the amount that can be collected. We wanted to let small devices transmit profile data while making as few temporary copies as possible. Since it seemed likely that other sorts of tools would need to exchange large binary blocks efficiently, we wanted this capability to be usable by any protocol participant, rather than being tailored to the profiler's specific case.
+
+In our implementation of this Stream Transport, when a participant wishes to transmit a bulk data packet, it provides the data's length in bytes, and a callback function. When data can be sent, the transport passes the callback function the underlying <code>nsIOutputStream</code>, and the callback writes the data directly to the stream. Thus, the transport itself requires no intermediate copies of the data; the packet can be sent as efficiently as the underlying tool can manage. Similarly, when a participant receives a bulk data packet, the transport passes the actor name and the transport's underlying <code>nsIInputStream</code> directly to a callback function registered for the purpose. The callback function can then consume the data directly, and again, the transport itself requires no intermediate copies.
+
 <!-- Local Variables: -->
 <!-- eval: (visual-line-mode) -->
 <!-- End: -->

--- a/transport
+++ b/transport
@@ -1,0 +1,55 @@
+The [[Remote_Debugging_Protocol|Mozilla debugging protocol]] is specified in terms of packets exchanged between a client and server, where each packet is either a JSON text or a block of bytes (a "bulk data" packet). The protocol does not specify any particular mechanism for carrying packets from one party to the other. Implementations may choose whatever transport they like, as long as packets arrive reliably, undamaged, and in order.
+
+This page describes the <b>Mozilla Remote Debugging Protocol Stream Transport</b>, a transport layer suitable for carrying Mozilla debugging protocol packets over a reliable, ordered byte stream, like a TCP/IP stream or a pipe. Debugger user interfaces can use it to exchange packets with debuggees in other processes (say, for debugging Firefox chrome code), or on other machines (say, for debugging Firefox OS apps running on a phone or tablet).
+
+(The Stream Transport is not the only transport used by Mozilla. For example, when using Firefox's built-in script debugger, the client and server are in the same process, so for efficiency they use a transport that simply exchanges the JavaScript objects corresponding to the JSON texts specified by the protocol, and avoid serializing packets altogether.)
+
+== Packets ==
+
+Once the underlying byte stream is established, transport participants may immediately begin sending packets, using the forms described here. The transport requires no initial handshake or setup, and no shutdown exchange: the first bytes on the stream in each direction are those of the first packet, if any; the last bytes on the stream in each direction are the final bytes of the last packet sent, if any.
+
+The transport defines two types of packets: JSON and bulk data.
+
+=== JSON Packets ===
+
+A JSON packet has the form:
+
+  <i>length</i>:<i>JSON</i>
+
+where <i>length</i> is a series of decimal ASCII digits, <i>JSON</i> is a well-formed JSON text (as defined in [http://www.ietf.org/rfc/rfc4627.txt RFC 4627]) encoded in UTF-8, and <i>length</i>, interpreted as a number, is the length of <i>JSON</i> in bytes.
+
+=== Bulk Data Packets ===
+
+A bulk data packet has the form:
+
+  bulk <i>actor</i> <i>length</i>:<i>data</i>
+
+where:
+<ul>
+<li><code>bulk</code> is the four ASCII characters 'b', 'u', 'l', and 'k';
+<li>there is exactly one space character (the single byte 0x20) between <code>bulk</code> and <i>actor</i>, and between <i>actor</i> and <i>length</i>;
+<li><i>actor</i> is a sequence of Unicode characters, encoded in UTF-8, containing no spaces or colons;
+<li><i>length</i> is a sequence of decimal ASCII digits; and
+<li><i>data</i> is a sequence of bytes whose length is <i>length</i> interpreted as a number.
+</ul>
+
+The <i>actor</i> field is the name of the actor sending or receiving the packet. (Actors are server-side entities, so if the packet was sent by the client, <i>actor</i> names the recipient; and if the packet was sent by the server, <i>actor</i> names the sender.) The protocol imposes the same syntactic restrictions on actor names that we require here.
+
+Which actor names are valid at any given point in an exchange is established by the remote debugging protocol.
+
+The content of a bulk data packet is exactly the sequence of bytes appearing as <i>data</i>. <i>Data</i> is not UTF-8 text.
+
+== Stream Requirements ==
+
+The Stream Transport requires the underlying stream to have the following properties:
+<ul>
+<li>It must be <b>transparent</b>: each transmitted byte is carried to the recipient without modification. Bytes whose values are ASCII control characters or fall outside the range of ASCII altogether must be carried unchanged; line terminators are left alone.
+<li>It must be <b>reliable</b>: every transmitted byte makes it to the recipient, or else the connection is dropped altogether. Errors introduced by hardware, say, must be detected and corrected, or at least reported (and the connection dropped). The Stream Transport includes no checksums of its own; those are the stream's responsibility. (So, for example, a plain serial line is not suitable for use as an underlying stream.)
+<li>It must be <b>ordered</b>: bytes are received in the same order they are transmitted, and bytes are not duplicated. (UDP packets, for example, may be duplicated or arrive out of order.)
+</ul>
+
+TCP/IP streams and USB streams meet these requirements.
+
+<!-- Local Variables: -->
+<!-- eval: (visual-line-mode) -->
+<!-- End: -->

--- a/transport
+++ b/transport
@@ -26,8 +26,7 @@ A bulk data packet has the form:
 
 where:
 <ul>
-<li><code>bulk</code> is the four ASCII characters 'b', 'u', 'l', and 'k';
-<li>there is exactly one space character (the single byte 0x20) between <code>bulk</code> and <i>actor</i>, and between <i>actor</i> and <i>length</i>;
+<li>The keyword <code>bulk</code> is encoded in ASCII, and the spaces are always exactly one ASCII space.
 <li><i>actor</i> is a sequence of Unicode characters, encoded in UTF-8, containing no spaces or colons;
 <li><i>length</i> is a sequence of decimal ASCII digits; and
 <li><i>data</i> is a sequence of bytes whose length is <i>length</i> interpreted as a number.
@@ -52,11 +51,11 @@ TCP/IP streams and USB streams meet these requirements.
 
 == Implementation Notes ==
 
-=== Zero-copy Bulk Data ===
+=== Constant-Overhead Bulk Data ===
 
-Mozilla added bulk data packets to the protocol to download profiling data from devices with limited memory more efficiently. Profiling data sets need to be as large as possible, as larger sets can cover a longer period of time or more frequent samples. However, converting a large data set to a JavaScript object, converting the object to a JSON text, and sending the text over the connection entails making several temporary copies of the data, and thus limits the amount that can be collected. We wanted to let small devices transmit profile data while making as few temporary copies as possible. Since it seemed likely that other sorts of tools would need to exchange large binary blocks efficiently, we wanted this capability to be usable by any protocol participant, rather than being tailored to the profiler's specific case.
+Mozilla added bulk data packets to the protocol to let devices with limited memory upload performance profiling data more efficiently. Profiling data sets need to be as large as possible, as larger data sets can cover a longer period of time or more frequent samples. However, converting a large data set to a JavaScript object, converting that object to a JSON text, and sending the text over the connection entails making several temporary complete copies of the data; on small devices, this limits how much data the profiler can collect. Avoiding these temporary copies would allow small devices to collect and transmit larger profile data sets. Since it seemed likely that other sorts of tools would need to exchange large binary blocks efficiently as well, we wanted a solution usable by all protocol participants, rather than one tailored to the profiler's specific case.
 
-In our implementation of this Stream Transport, when a participant wishes to transmit a bulk data packet, it provides the data's length in bytes, and a callback function. When data can be sent, the transport passes the callback function the underlying <code>nsIOutputStream</code>, and the callback writes the data directly to the stream. Thus, the transport itself requires no intermediate copies of the data; the packet can be sent as efficiently as the underlying tool can manage. Similarly, when a participant receives a bulk data packet, the transport passes the actor name and the transport's underlying <code>nsIInputStream</code> directly to a callback function registered for the purpose. The callback function can then consume the data directly, and again, the transport itself requires no intermediate copies.
+In our implementation of this Stream Transport, when a participant wishes to transmit a bulk data packet, it provides the actor name, the data's length in bytes, and a callback function. When the underyling stream is ready to send more data, the transport writes the packet's <code>bulk <i>actor</i> <i>length</i>:</code> header, and then passes the underlying <code>nsIOutputStream</code> to the callback, which then writes the packet's <i>data</i> portion directly to the stream. Similarly, when a participant receives a bulk data packet, the transport parses the header, and then passes the actor name and the transport's underlying <code>nsIInputStream</code> to a callback function, which consumes the data directly. Thus, while the callback functions may well use fixed-size buffers to send and receive data, the transport imposes no overhead proportional to the full size of the data.
 
 <!-- Local Variables: -->
 <!-- eval: (visual-line-mode) -->

--- a/transport
+++ b/transport
@@ -59,4 +59,5 @@ In our implementation of this Stream Transport, when a participant wishes to tra
 
 <!-- Local Variables: -->
 <!-- eval: (visual-line-mode) -->
+<!-- page-delimiter: "^=" -->
 <!-- End: -->


### PR DESCRIPTION
Most of this is from your existing "bulk-transport" branch. I've also described the type field, and allowed colons in the actor name, as it is still possible to parse the header when colons are present.
